### PR TITLE
fix(server): listen specifically for IPv4 connections

### DIFF
--- a/app.js
+++ b/app.js
@@ -340,7 +340,7 @@ async function main() {
 //=============================================================================
 
 console.log("LAMP - App Gateway");
-const server = app.listen(PORT, () => {
+const server = app.listen(PORT, "0.0.0.0", () => {
   const { address, port } = server.address();
   console.log(`Listening on ${address}:${port}`);
 });


### PR DESCRIPTION
HTTP servers listen on TCP/IP sockets. To listen on a specific port, an HTTP server creates a new socket using a `${address}:${port}` pair.

Common pairs in development are (using port 8080 as an example):

  - `127.0.0.1:8080` - [IPv4] Listen on the loopback device (only private traffic)

  - `0.0.0.0:8080`   - [IPv4] Listen to all _IPv4_ addresses

    Where `0.0.0.0` is a special address that will accept traffic to:
      - `127.0.0.1:8080`     - localhost
      - `192.168.0.30:8080`  - example private ip address
      - `8.8.8.155:8080`     - example public ip address
      - ... etc, etc ...

  - `[::1]:8080`     - [IPv6] Listen on the loopback device (only private
                     traffic)

  - `[::]:8080`      - [IPv6] Listen to all _IPv6_ addresses
                     Similar to `0.0.0.0`, but for all IPv6 addresses

Note that the IP protocol version _must_ match. You cannot make an IPv4 request to an IPv6 socket. In our case, with the node upgrade, we started listening to `[::]:8081` by default (instead of 0.0.0.0:8081 pre-upgrade); but our health check was still querying `http://localhost:8081`, which translates to `http://127.0.0.1:8081`. So we assumed the container was dead when it may not have been.

To fix this, we can either update our health check to use IPv6 or upgrade our server to listen on an IPv4 socket. I've chosen the later in this commit in case any of AWS's internal tooling or available health check commands are not yet able to speak IPv6. IPv6 adoption has been historically slow.