### PR TITLE
CI: auto-deploy to dev env instead of stg

### DIFF
--- a/.github/workflows/callable-deploy-ecs.yml
+++ b/.github/workflows/callable-deploy-ecs.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       env:
-        description: Target environment of deployment. (stg, prod)
+        description: Target environment of deployment. (dev, stg, prod)
         required: true
         type: string
       container_digest:

--- a/.github/workflows/manual-deploy-sha.yml
+++ b/.github/workflows/manual-deploy-sha.yml
@@ -8,7 +8,7 @@ on:
         description: Git sha (long format) to build and deploy
       env:
         type: environment
-        default: stg
+        default: dev
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.sha }}

--- a/.github/workflows/on-merge-to-master.yml
+++ b/.github/workflows/on-merge-to-master.yml
@@ -18,12 +18,12 @@ jobs:
     with:
       push: true
 
-  deploy-env-stg:
-    name: "Deploy Staging"
+  deploy-env-dev:
+    name: "Deploy Development"
     uses: ./.github/workflows/callable-deploy-ecs.yml
     secrets: inherit
     with:
-      env: stg
+      env: dev
       container_digest: ${{ needs.build-docker.outputs.container_image_digest }}
     needs: 
       - build-docker

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ dist
 
 # Google Credentials
 *-adminsdk-*.json
+
+# macOS system files
+.DS_Store


### PR DESCRIPTION
Chore: Add macOS .DS_Store files to the .gitignore
CI: Update master builds to deploy to dev environment instead of the staging environment